### PR TITLE
fix: crystal v1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,6 @@ run:
 	$(CRYSTAL) run src/secrets-cli.cr
 
 build:
-	shards build --production
+	shards build --no-debug --release --production
 
 .phony:

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,6 @@ run:
 	$(CRYSTAL) run src/secrets-cli.cr
 
 build:
-	shards build --no-debug --release
+	shards build --production
 
 .phony:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Command line interface for the [Crystal Secrets](https://github.com/HCLarsen/sec
 1. Clone this repo:
 
 ```
-git clone https://github.com/HCLarsen/secrets.git
+git clone https://github.com/HCLarsen/secrets-cli.git
 ```
 
 2. Build:

--- a/shard.lock
+++ b/shard.lock
@@ -5,6 +5,6 @@ shards:
     version: 0.5.1
 
   secrets:
-    git: https://github.com/HCLarsen/secrets.git
-    version: 0.1.0+git.commit.9840e2c79b45829e12020633c272eedffea98a81
+    git: https://github.com/hclarsen/secrets.git
+    version: 0.1.0+git.commit.b73878ce8b225d81c847df6e06e2ec4786a54a23
 


### PR DESCRIPTION
While trying to install CLI I've stumbled upon several small problems:
1. Wrong git repo URI in README
2. Shards v0.14.1 fails to run `make build` with following error:
```
Unable to satisfy the following requirements:

- `crystal (~> 0.35, >= 0.35.1)` required by `secrets 0.1.0+git.commit.9840e2c79b45829e12020633c272eedffea98a81`
- `crystal (~> 0.34, >= 0.34.0)` required by `minitest 0.5.1`
Failed to resolve dependencies, try updating incompatible shards or use --ignore-crystal-version as a workaround if no update is available.
```
To fix this error, I've updated commit of `secrets` in `shard.lock` and added `--production` option (same as `--frozen --without-development`) to `shard build` in Makefile (note that it was only [added in 2015](https://github.com/crystal-lang/shards/blob/master/CHANGELOG.md#v040---2015-09-14))